### PR TITLE
Fix path processing logic in addToMdocRequest

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptorField.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptorField.kt
@@ -28,10 +28,11 @@ data class InputDescriptorField(
     }
 
     fun addToMdocRequest(mDocRequestBuilder: MDocRequestBuilder, intentToRetain: Boolean = false): MDocRequestBuilder {
-        path.firstOrNull()?.trimStart('$')?.replace("['", "")?.replace("']", ".")?.trimEnd('.')?.split('.')
-            ?.also { pathSegments ->
-            mDocRequestBuilder.addDataElementRequest(pathSegments.first(), pathSegments.last(), intentToRetain)
-        }
+        path.firstOrNull()?.trimStart('$')?.replace("['", "")?.replace("']", ".")?.trimEnd('.')
+            ?.let { it.substringBeforeLast('.') to it.substringAfterLast('.') }
+            ?.also { (namespace, lastSegment) ->
+                mDocRequestBuilder.addDataElementRequest(namespace, lastSegment, intentToRetain)
+            }
         return mDocRequestBuilder
     }
 }


### PR DESCRIPTION
## Description

Currently by requesting an iso/mdoc from the Wallet resulting a wallet sending a mdoc which does not contains any attributes in the presentation request. This is due to the processing logic in the `addToMdocRequest` function [(here)](https://github.com/walt-id/waltid-identity/blob/main/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptorField.kt#L31)  

Currently, this line splits the namespace concatenated with the claim using a `.` as the delimiter. However, for namespaces that already contain a `.` (such as those in mdl), this causes the claim and the namespace to be incorrectly split and then added to the MDocRequestBuilder. In case of `org.iso.18013.5.1`, only `org` is set to be the namespace. This is leading to incorrect behavior, as the claim isn't being processed as expected.

The following is one of the presentation_definition I have used: 

```` json
{
    "id": "7c80dc00-604f-4edd-9956-87a2426437fa",
    "input_descriptors": [
      {
        "id": "org.iso.18013.5.1.mDL",
        "purpose": "verify mdl of users",
        "format": {
          "mso_mdoc": {
            "alg": [
              "ECDSA"
            ]
          }
        },
        "constraints": {
          "fields": [
            {
              "path": [
                "$['org.iso.18013.5.1']['given_name']"
              ],
              "filter": {
                "type": "string",
                "pattern": ".*"
              },
              "intent_to_retain": true
            }
          ],
          "limit_disclosure": "required"
        }
      }
    ]
  }
````

## Type of Change

- [x ] bug fix - change which fixes an issue


## Checklist

- [x ] code cleanup and self-review
